### PR TITLE
Removing "volumes_from" and data container from stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,13 @@
 version: '2'
 services:
-  backend:
-    image: debian:jessie
-    volumes:
-      - .:/var/www
   nginx:
     build: docker/nginx
     ports:
       - 80
-    volumes_from:
-      - backend
+    volumes:
+      - .:/var/www
   php_nginx:
     build: docker/php
-    volumes_from:
-      - backend
   db:
     image: mariadb
     environment:
@@ -21,9 +15,15 @@ services:
       MYSQL_PASSWORD: expresso-php
       MYSQL_DATABASE: expresso-php
       MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - dbdata:/var/lib/mysql
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
       - 80
     environment:
       MYSQL_ROOT_PASSWORD: root
+volumes:
+## persistent data volume for mysql data
+  dbdata:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - .:/var/www
   php_nginx:
     build: docker/php
+    volumes:
+      - .:/var/www
   db:
     image: mariadb
     environment:


### PR DESCRIPTION
This PR brings the yaml configuration into compliance with version 3 formatting, which was introduced with Docker Engine 1.13.0; however I am leaving the version at '2' this change is backwards compatible.

The switch to a "volumes" declaration within the two services eliminates the need for the "backend" data container.

In addition I've added a data volume to the "db" service so that the database created by the "db" service can persist even if the services are destroyed.  This will allow for upgrading a db service on a project to a newer version without losing the database itself, and without the need to back it up.