### PR TITLE
Issue 30. Creating an entrypoint file for permissions handling

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,5 +1,17 @@
 FROM php:7-apache
 
+# Install & configure gosu.
+# Many thanks to https://denibertovic.com/posts/handling-permissions-with-docker-volumes/
+RUN apt-get update && apt-get -y --no-install-recommends install \
+    ca-certificates \
+    curl
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture)" &&\
+    curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.4/gosu-$(dpkg --print-architecture).asc" &&\
+    gpg --verify /usr/local/bin/gosu.asc &&\
+    rm /usr/local/bin/gosu.asc &&\
+    chmod +x /usr/local/bin/gosu
+
 RUN apt-get update -qq \
   && apt-get install wget mysql-client -yq
 
@@ -35,4 +47,14 @@ RUN php drush core-status
 RUN chmod +x drush
 RUN mv drush /usr/local/bin
 
+# Set directory permissions on /var/www:
+RUN chown www-data:www-data /var/www
+
+# Set a Docker entrypoint script:
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod 755 /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
 WORKDIR /var/www/web
+
+CMD ["apache2-foreground"]

--- a/docker/php/entrypoint.sh
+++ b/docker/php/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Change user:group id values for 'www-data:www-data' to match the uid:gid of
+# the project docroot, unless the uid:gid are set to 0:0.
+USER_ID=$(stat -c '%u' /var/www/html)
+GROUP_ID=$(stat -c '%g' /var/www/html)
+if [ $USER_ID != 0 ]; then
+  usermod -u $USER_ID www-data
+fi
+if [ $GROUP_ID != 0 ]; then
+  groupmod -g $GROUP_ID www-data
+  find /var/www -group 33 -exec chgrp -h www-data {} \;
+fi
+
+if [ $1 = "apache2-foreground" ] || [ $1 = "php-fpm" ]; then
+  # If first arg is `php` or `php-fpm`, then run as user root.
+  exec "$@"
+elif [ -n $1 ]; then
+  # If first arg is anything else, then execute as user "www-data".
+  exec /usr/local/bin/gosu www-data "$@"
+else
+  # If entrypoint.sh is called with no arg, execute as user root.
+  exec "$@"
+fi


### PR DESCRIPTION
Use an entrypoint script to set www-data user/group id, and use
`gosu` to allow bash logins as www-data.