### PR TITLE
Issue 15. DNS Names apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,18 @@ FROM php:5-apache
 ```
 
 ### Get started
-All your Drupal files should be placed into the folder "web".
+Add the project domain to your local Hosts file, and point it to
+`127.0.100.100`.
+- Paste the following into `/etc/hosts`
+  (`c:\Windows\System32\drivers\etc\hosts` for Windows users):
+
+        127.0.100.100  expresso.dev db.expresso.dev
+
+    - Mac users: Run the following to attach an unused IP to the lo0 interface.
+
+            sudo ifconfig lo0 alias 127.0.100.100/24
+
+All your PHP files should be placed into the folder "web".
 
 Run docker compose.
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,11 @@ version: '2'
 services:
   php_apache:
     build: docker/php
-    links:
-      - db:db.expresso.dev
     ports:
       - 127.0.100.100:80:80
     volumes:
       - .:/var/www
-  db:
+  db.expresso-php.dev:
     image: mariadb
     environment:
       MYSQL_USER: expresso-php
@@ -23,8 +21,6 @@ services:
       - 127.0.100.100:8181:80
     environment:
       MYSQL_ROOT_PASSWORD: root
-    links:
-      - db
 volumes:
 ## persistent data volume for mysql data
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: '2'
 services:
   php_apache:
     build: docker/php
+    links:
+      - db:db.expresso.dev
     ports:
-      - 80
+      - 127.0.100.100:80:80
     volumes:
       - .:/var/www
   db:
@@ -18,9 +20,11 @@ services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
-      - 80
+      - 127.0.100.100:8181:80
     environment:
       MYSQL_ROOT_PASSWORD: root
+    links:
+      - db
 volumes:
 ## persistent data volume for mysql data
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - 127.0.100.100:8181:80
     environment:
       MYSQL_ROOT_PASSWORD: root
+    links:
+      - db.expresso-php.dev:db
 volumes:
 ## persistent data volume for mysql data
   dbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,11 @@ version: '2'
 services:
   php_apache:
     build: docker/php
-    links:
-      - db:db.expresso.dev
     ports:
       - 127.0.100.100:80:80
     volumes:
       - .:/var/www
-  db:
+  db.expresso.dev:
     image: mariadb
     environment:
       MYSQL_USER: expresso-php
@@ -24,7 +22,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
     links:
-      - db
+      - db.expresso.dev:db
 volumes:
 ## persistent data volume for mysql data
   dbdata:


### PR DESCRIPTION
Providing a way to set container IP addresses that is advertised to work in both Linux and Mac.

Tying the php and db containers to an IP address (with ports 80 and 3306, respectively) also allows developers to use CLI tools like `drush` seamlessly from the host machine's command line!