### PR TITLE
Issue #30. Address file ownership issues for Linux-based host machines apache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Docker Compose environment file.
+/.env

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ FROM php:5-apache
 ### Get started
 All your Drupal files should be placed into the folder "web".
 
+Identify your host machine's user & group id's and reassign the Docker container
+service `www-data` user & group id's to read and write files with uid:gid values
+equal to the host machine. Run the following to declare uid and gid values in
+Docker-Compose environment variable file `/.env`.
+```sh
+echo "HOST_UID=$(id -u)" > .env
+echo "HOST_GID=$(id -g)" >> .env
+```
+
 Run docker compose.
 ```
 $ docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
-version: '2'
+version: '2.1'
 services:
   php_apache:
-    build: docker/php
+    build:
+      context: docker/php
+      args:
+        HOST_UID: ${HOST_UID:-1000}
+        HOST_GID: ${HOST_GID:-1000}
     ports:
       - 80
     volumes:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -35,4 +35,16 @@ RUN php drush core-status
 RUN chmod +x drush
 RUN mv drush /usr/local/bin
 
+# Update the www-data services's uid & gid to match the mounted file system.
+# As a default, use 1000:1000.
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+RUN usermod -u ${HOST_UID} www-data &&\
+    groupmod -g ${HOST_GID} www-data
+
+# Change ownership of some system directories to grant control to `www-data`.
+RUN chown www-data:www-data /var/www &&\
+    chown -Rf www-data:www-data /usr/local/etc/php &&\
+    chown -Rf www-data:www-data /tmp
+
 WORKDIR /var/www/web


### PR DESCRIPTION
The host machine's user id and group id can be passed to Docker containers as environment variables, so that the www-data service will run with the same user and group id's that the host machine uses for file ownership.