### PR TITLE
Issue #16. Adding MailHog to the Docker environment apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ What's included:
   - PHP
   - Mariadb
   - PhpMyAdmin
+  - Mailhog
 
 Check the other branches of this repo for some more options.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       - 80
     environment:
       MYSQL_ROOT_PASSWORD: root
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - 8025
 volumes:
 ## persistent data volume for mysql data
   dbdata:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -25,6 +25,16 @@ RUN { \
         echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
+# Install MailHog Sendmail support.
+RUN apt-get update -qq && apt-get install -yq git golang-go &&\
+    mkdir -p /opt/go &&\
+    export GOPATH=/opt/go &&\
+    go get github.com/mailhog/mhsendmail
+
+# Copy PHP configs.
+COPY conf.d/* /usr/local/etc/php/conf.d/
+RUN chmod 644 /usr/local/etc/php/conf.d/*
+
 # Install drush.
 # Download latest stable release using the code below or browse to github.com/drush-ops/drush/releases.
 RUN php -r "readfile('https://s3.amazonaws.com/files.drush.org/drush.phar');" > drush

--- a/docker/php/conf.d/mailhog.ini
+++ b/docker/php/conf.d/mailhog.ini
@@ -1,0 +1,3 @@
+; Mailhog php.ini settings for Expresso PHP.
+
+sendmail_path = "/opt/go/bin/mhsendmail --smtp-addr=mailhog:1025"


### PR DESCRIPTION
Adding MailHog catcher and sendmail support to the Docker environment to allow php sendmail-based email testing.