### PR TITLE
Remove nginx caching for css and js files.

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -96,7 +96,9 @@ server {
     }
 
     location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-        expires max;
+        # Expires negative value removes unnecessary caching of JS/CSS for local
+        # development.
+        expires -1;
         log_not_found off;
     }
 }


### PR DESCRIPTION
Using this with Drupal 8.  

I followed all instructions at https://www.drupal.org/node/2598914, in order to setup a development environment without any caches (twig/js/css).  However after setting this up, twig now works fine, but js (and presumably css) still remains cached after editing the file.  I had to clear caches before any js edits take place.  

After replacing expires max; with expires 1; solves the problem.  js (and presumably css) file edits now takes affect without clearing caches.  

Hooray for faster drupal development environment setup.