### PR TITLE
Issue #70: Replacing mysql-client with mariadb-client, for Nginx.

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7-fpm
 
 RUN apt-get update -qq \
-  && apt-get install wget mysql-client -yq
+  && apt-get install wget mariadb-client -yq
 
 # install the PHP extensions we need
 RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev libzip-dev zip \


### PR DESCRIPTION
Replacing `mysql-client` with `mariadb-client`. 

Reference: https://stackoverflow.com/questions/57048428/e-package-mysql-client-has-no-installation-candidate-in-php-fpm-image-build-u