### PR TITLE
Issue #70: Replacing mysql-client with mariadb-client, for Apache.

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7-apache
 
 RUN apt-get update -qq \
-  && apt-get install wget mysql-client -yq
+  && apt-get install wget mariadb-client -yq
 
 RUN a2enmod rewrite
 


### PR DESCRIPTION
Replacing mysql-client with mariadb-client.

Reference: https://stackoverflow.com/questions/57048428/e-package-mysql-client-has-no-installation-candidate-in-php-fpm-image-build-u